### PR TITLE
Create incomplete first pass of env noise addition

### DIFF
--- a/animal/noise.py
+++ b/animal/noise.py
@@ -1,0 +1,52 @@
+"""This module contains Environment wrappers for noise observation and action noise."""
+
+import numpy as np
+from gym import Env
+from gym.core import ActionWrapper, ObservationWrapper
+from gym.spaces import Box, Discrete
+
+
+class BetaNoiseObservationWrapper(ObservationWrapper):
+    """Gym wrapper for adding Beta noise to observation space."""
+
+    def __init__(self, env: Env, alpha: int = 1, beta: int = 1) -> None:
+        assert type(env.observation_space) in (Box, Discrete), "Only `Box` and `Discrete` spaces supported"
+
+        super().__init__(env)
+
+        space = env.observation_space
+
+        self._env_obs_discrete = isinstance(space, Discrete)
+        self._env_obs_dim = (1,) if self._env_obs_discrete else space.shape
+        self._env_obs_min = np.array([0]) if self._env_obs_discrete else space.low
+        self._env_obs_max = np.array([space.n]) if self._env_obs_discrete else space.high
+
+        self._noise_param_alpha, self._noise_param_beta = alpha, beta
+        self._noise_dist_mean = self._noise_param_alpha / (self._noise_param_alpha + self._noise_param_beta)
+
+    def observation(self, observation: np.ndarray) -> np.ndarray:
+        noise = np.random.beta(self._noise_param_alpha, self._noise_param_beta, size=self._env_obs_dim)
+        return np.clip(observation * (1 + noise - self._noise_dist_mean), self._env_obs_min, self._env_obs_max)
+
+
+class BetaNoiseActionWrapper(ActionWrapper):
+    """Gym wrapper for adding Beta noise to action space."""
+
+    def __init__(self, env: Env, alpha: int = 1, beta: int = 1) -> None:
+        assert type(env.action_space) in (Box, Discrete), "Only `Box` and `Discrete` spaces supported"
+
+        super().__init__(env)
+
+        space = env.action_space
+
+        self._env_act_discrete = isinstance(space, Discrete)
+        self._env_act_dim = (1,) if self._env_act_discrete else space.shape
+        self._env_act_min = np.array([0]) if self._env_act_discrete else space.low
+        self._env_act_max = np.array([space.n]) if self._env_act_discrete else space.high
+
+        self._noise_param_alpha, self._noise_param_beta = alpha, beta
+        self._noise_dist_mean = self._noise_param_alpha / (self._noise_param_alpha + self._noise_param_beta)
+
+    def action(self, action: np.ndarray) -> np.ndarray:
+        noise = np.random.beta(self._noise_param_alpha, self._noise_param_beta, size=self._env_act_dim)
+        return np.clip(action * (1 + noise - self._noise_dist_mean), self._env_act_min, self._env_act_max)

--- a/animal/ppo.py
+++ b/animal/ppo.py
@@ -15,6 +15,7 @@ import yaml
 from tqdm import tqdm
 from copy import deepcopy
 import time
+from animal import noise
 
 # TODO:
 #   1. Make minibatch size actually do something. One way is to tie into torch.Datasets and torch.DataLoaders, create new dataset and dataloader at the end of each batch
@@ -39,7 +40,9 @@ class PPO:
         env_kwargs: dict = {},
         agent_name: str = 'Agent',
         seed: int = 0,
-        device: str = "cpu"
+        device: str = "cpu",
+        beta_noise_obs: list = None,
+        beta_noise_act: list = None,
     ) -> None:
         if val_loss.lower() == "mse":
             self.val_loss = nn.MSELoss()
@@ -48,7 +51,12 @@ class PPO:
         else:
             raise ValueError(f"Value loss {val_loss} not supported. Use `mse` or `huber`.")
         self.tracker_dict = {}
-        self.env = TorchifyEnv(gym.make(env, **env_kwargs), device=device)
+
+        _env = gym.make(env, **env_kwargs)
+        _env = _env if not beta_noise_obs else noise.BetaNoiseObservationWrapper(_env, *beta_noise_obs)
+        _env = _env if not beta_noise_act else noise.BetaNoiseActionWrapper(_env, *beta_noise_act)
+        self.env = TorchifyEnv(_env, device=device)
+
         self.clipratio = clipratio
         self.batch_size = batch_size
         self.train_iters = train_iters
@@ -58,11 +66,11 @@ class PPO:
         self.epochs = epochs
         self.action_stats = RunningActionStats(self.env)
         self.agent_name = f"{env}-agent_name-{int(time.time())}"
-        self.episode_reward = 0 
-        self.episodes_completed = 0 
+        self.episode_reward = 0
+        self.episodes_completed = 0
         self.device = device
         torch.manual_seed(seed)
-        
+
         self.buffer = PGBuffer(
             obs_dim=self.env.observation_space.shape[0],
             act_dim=self.env.action_space.shape,
@@ -87,7 +95,7 @@ class PPO:
 
         kl = (logps_old - logps).mean().item()
         return pol_loss, kl
-    
+
     def calc_val_loss(self, values, rets):
         return self.val_loss(values, rets)
 
@@ -155,7 +163,7 @@ class PPO:
         return pol_out, val_out
 
     def get_batch(self) -> None:
-        
+
         state = self.env.reset()
         reward = 0
         R = 0
@@ -198,11 +206,11 @@ class PPO:
                     self.summary_writer.add_scalar('episode_reward', self.episode_reward, self.episodes_completed)
                     self.summary_writer.add_scalar('episode_length', episode_length, self.episodes_completed)
                     self.episode_reward = 0
-                
+
                 state = self.env.reset()
                 R = 0
                 episode_length = 0
-        
+
         track = {
             "MeanEpReturn": np.mean(rewlst),
             "StdEpReturn": np.std(rewlst),
@@ -227,7 +235,7 @@ class PPO:
                 print(f"{k}: {v}")
 
     def set_file_structure(self,config):
-        folder = os.path.join(os.getcwd(), 'tensorboards', self.agent_name) 
+        folder = os.path.join(os.getcwd(), 'tensorboards', self.agent_name)
         if not os.path.isdir(folder):
             os.makedirs(folder)
         self.summary_writer = SummaryWriter(logdir=folder)
@@ -257,7 +265,7 @@ def trainPPO(config):
     agent = PPO(**config)
     agent.set_file_structure(config)
     agent.run()
-           
+
 
 @click.command()
 @click.option("--config-file", "-cf", default="configs/default_ppo.yaml")
@@ -266,7 +274,7 @@ def main(
 ):
     with open(config_file, "rb") as f:
         config = yaml.safe_load(f)
-    
+
     if 'param_search' in config.keys():
         params = genConfigs(config)
         params_to_search = config['param_search']
@@ -279,7 +287,7 @@ def main(
     else:
         trainPPO(config)
 
-           
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Problem
-------
For SP22' semester of CS7643, Team PeRL is studying the effects of data
  perturbation within both observation and action spaces for both on and
  off policy algorithms. As part of the team proposal, three parameter 
  variations of the Beta distribution are to be used. For this to happen,
  enviroment wrappers are needed.

Solution
--------
- Create a new sub-module for observation and action perturbation
- Conditionally add wrappers to PPO and SAC algorithms

Tests
-----
- Input/output spaces have been reviewed for `LunarLanderContinuous-v2`

Notes
-----
- Discrete space has note been resolved for either space
- Wrapper integrations should be decoupled from algorithms
- Project should implement code formatted to avoid line-end changes
